### PR TITLE
feat: add credential test for JupiterOne API

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ To obtain your API token, log in to JupiterOne and generate an access token from
 
 ## Version history
 
+- 0.1.4
+  - Added Credential Test for J1 API
+
 - 0.1.3
   - Added JupiterOne Webhook node for receiving rule alerts and security events
 

--- a/credentials/JupiterOneApi.credentials.ts
+++ b/credentials/JupiterOneApi.credentials.ts
@@ -1,4 +1,4 @@
-import { IAuthenticateGeneric, ICredentialType, INodeProperties, Icon } from 'n8n-workflow';
+import { IAuthenticateGeneric, ICredentialType, INodeProperties, Icon, ICredentialTestRequest } from 'n8n-workflow';
 
 export class JupiterOneApi implements ICredentialType {
   name = 'jupiteroneApi';
@@ -42,6 +42,20 @@ export class JupiterOneApi implements ICredentialType {
       headers: {
         Authorization: 'Bearer {{ $credentials.accessToken }}',
         'Content-Type': 'application/json',
+      },
+    },
+  };
+
+  test: ICredentialTestRequest = {
+    request: {
+      baseURL: '={{ $credentials.apiBaseUrl }}',
+      url: '/graphql',
+      method: 'POST',
+      headers: {
+        'JupiterOne-Account': '={{ $credentials.accountId }}',
+      },
+      body: {
+        query: 'query TestQuery { queryV1(query: "FIND jupiterone_account LIMIT 1") { type data url } }',
       },
     },
   };


### PR DESCRIPTION
- Add ICredentialTestRequest import to support credential testing
- Implement test property with GraphQL endpoint validation
- Use simple jupiterone_account query to verify credentials
- Allow users to test JupiterOne API credentials in n8n interface
- Fixes n8n verification requirement for community nodes