### PR TITLE
Fixed n8n Test Credential Logic

### DIFF
--- a/credentials/JupiterOneApi.credentials.ts
+++ b/credentials/JupiterOneApi.credentials.ts
@@ -1,10 +1,17 @@
-import { IAuthenticateGeneric, ICredentialType, INodeProperties, Icon } from 'n8n-workflow';
+import {
+  IAuthenticateGeneric,
+  ICredentialType,
+  INodeProperties,
+  Icon,
+  ICredentialTestRequest,
+} from 'n8n-workflow';
 
 export class JupiterOneApi implements ICredentialType {
   name = 'jupiteroneApi';
   displayName = 'JupiterOne API';
   icon = 'file:jupiterone.svg' as Icon;
-  documentationUrl = 'https://docs.jupiterone.io/integrations/outbound-directory/n8n-community-node';
+  documentationUrl =
+    'https://docs.jupiterone.io/integrations/outbound-directory/n8n-community-node';
 
   properties: INodeProperties[] = [
     {
@@ -40,9 +47,21 @@ export class JupiterOneApi implements ICredentialType {
     type: 'generic',
     properties: {
       headers: {
-        Authorization: 'Bearer {{ $credentials.accessToken }}',
+        Authorization: `=Bearer {{ $credentials.accessToken }}`,
         'Content-Type': 'application/json',
       },
+    },
+  };
+
+  test: ICredentialTestRequest = {
+    request: {
+      method: 'POST',
+      url: '={{ $credentials.apiBaseUrl }}/graphql',
+      headers: {
+        'JupiterOne-Account': '={{ $credentials.accountId }}',
+        'Content-Type': 'application/json',
+      },
+      body: '{"query":"query TestQuery { __typename }","variables":{}}',
     },
   };
 }

--- a/nodes/JupiterOneQuery/JupiterOneQuery.node.ts
+++ b/nodes/JupiterOneQuery/JupiterOneQuery.node.ts
@@ -100,7 +100,7 @@ export class JupiterOneQuery implements INodeType {
         const credentials = await this.getCredentials('jupiteroneApi');
         const accountId = credentials.accountId as string;
         const accessToken = credentials.accessToken as string;
-        const apiBaseUrl = (credentials.apiBaseUrl as string) || 'https://api.us.jupiterone.io';
+        const apiBaseUrl = credentials.apiBaseUrl as string;
         const graphqlEndpoint = `${apiBaseUrl.replace(/\/$/, '')}/graphql`;
 
         let baseQuery = this.getNodeParameter('query', i) as string;


### PR DESCRIPTION
Fixed n8n Test Credentials:

- Bumped n8n to latest version for testing (1.106.3)
- Fixed Authorization format as per n8n test interface
- Removed fallback for Prod URL